### PR TITLE
How to not send notification if no modification date

### DIFF
--- a/src/Extension/ReviewContentNotification.php
+++ b/src/Extension/ReviewContentNotification.php
@@ -550,6 +550,7 @@ final class ReviewContentNotification extends CMSPlugin implements SubscriberInt
             ->select($db->quoteName(['id', 'title', 'created', 'modified', 'catid', 'created_by', 'state', 'language']))
             ->from($db->quoteName('#__content'))
             ->where($db->quoteName('modified') . ' < :minimum_datetime')
+            ->where($db->quoteName('modified_by') . ' <> 0')
             // Get only published articles
             ->whereIn($db->quoteName('state'), $states)
             ->setLimit($limit)


### PR DESCRIPTION
When an article isn't modified, notifications are sent because the modification date is "0000-00-00 00:00:00". After adding this where clause, notification are only sent after article have been modified after the time defined in the task plugin.